### PR TITLE
[#54] 유저 모달 cookie 정보 사용 및 개선

### DIFF
--- a/src/components/CouponList/CouponItem/CouponExpose/index.tsx
+++ b/src/components/CouponList/CouponItem/CouponExpose/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 import theme from '@styles/theme';
@@ -7,6 +7,7 @@ import toggleOffIcon from '@assets/icons/ic-couponlist-toggleOff.svg';
 import rightIcon from '@assets/icons/ic-couponlist-right.svg';
 import deleteIcon from '@assets/icons/ic-couponlist-delete.svg';
 import { ToggleStyleProps } from '@/types/couponList';
+import { useOutsideClick } from '@hooks/index';
 
 const CouponExpose = () => {
   const [isToggle, setIsToggle] = useState(true);
@@ -21,21 +22,7 @@ const CouponExpose = () => {
     setIsRoomList(!isRoomList);
   };
 
-  useEffect(() => {
-    const handleClickListOutside = (e: MouseEvent) => {
-      if (
-        roomListRef.current &&
-        !roomListRef.current.contains(e.target as Node)
-      ) {
-        setIsRoomList(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickListOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickListOutside);
-    };
-  });
+  useOutsideClick(roomListRef, setIsRoomList);
 
   return (
     <CouponContainer $isToggle={isToggle}>

--- a/src/components/CouponList/CouponItem/CouponExpose/index.tsx
+++ b/src/components/CouponList/CouponItem/CouponExpose/index.tsx
@@ -22,7 +22,7 @@ const CouponExpose = () => {
     setIsRoomList(!isRoomList);
   };
 
-  useOutsideClick(roomListRef, setIsRoomList);
+  useOutsideClick(roomListRef, () => setIsRoomList(false));
 
   return (
     <CouponContainer $isToggle={isToggle}>

--- a/src/components/common/Layout/Header/User/UserModal/index.tsx
+++ b/src/components/common/Layout/Header/User/UserModal/index.tsx
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import styled from '@emotion/styled';
 
 import { UserModal, UserModalStyleProps } from '@/types/layout';
-import useOutsideClick from '@hooks/lib/useOutsideClick';
+import { useOutsideClick } from '@hooks/index';
 import theme from '@styles/theme';
 
 const UserModal = ({ isOpen, setIsUserModalOpen }: UserModal) => {

--- a/src/components/common/Layout/Header/User/UserModal/index.tsx
+++ b/src/components/common/Layout/Header/User/UserModal/index.tsx
@@ -3,10 +3,13 @@ import styled from '@emotion/styled';
 
 import { UserModal, UserModalStyleProps } from '@/types/layout';
 import { useOutsideClick } from '@hooks/index';
+import { getCookies } from '@utils/lib/cookies';
 import theme from '@styles/theme';
 
 const UserModal = ({ isOpen, setIsUserModalOpen }: UserModal) => {
-  // HACK: cookie에서 사용자 정보 가져오기
+  const userName = getCookies('userName');
+  const userEmail = getCookies('userEmail');
+
   const modalRef = useRef<HTMLDivElement>(null);
 
   useOutsideClick(modalRef, setIsUserModalOpen);
@@ -17,8 +20,8 @@ const UserModal = ({ isOpen, setIsUserModalOpen }: UserModal) => {
       ref={modalRef}
     >
       <UserInformation>
-        <Name $isOpen={isOpen}>김사장님</Name>
-        <Email $isOpen={isOpen}>yanolja123@yanolja.com</Email>
+        <Name $isOpen={isOpen}>{userName}</Name>
+        <Email $isOpen={isOpen}>{userEmail}</Email>
       </UserInformation>
       <Logout $isOpen={isOpen}>로그아웃</Logout>
     </Modal>

--- a/src/components/common/Layout/Header/User/UserModal/index.tsx
+++ b/src/components/common/Layout/Header/User/UserModal/index.tsx
@@ -7,12 +7,11 @@ import { getCookies } from '@utils/lib/cookies';
 import theme from '@styles/theme';
 
 const UserModal = ({ isOpen, setIsUserModalOpen }: UserModal) => {
+  const modalRef = useRef<HTMLDivElement>(null);
   const userName = getCookies('userName');
   const userEmail = getCookies('userEmail');
 
-  const modalRef = useRef<HTMLDivElement>(null);
-
-  useOutsideClick(modalRef, setIsUserModalOpen);
+  useOutsideClick(modalRef, () => setIsUserModalOpen(false));
 
   return (
     <Modal

--- a/src/components/common/Layout/Header/User/UserModal/index.tsx
+++ b/src/components/common/Layout/Header/User/UserModal/index.tsx
@@ -78,5 +78,6 @@ const Logout = styled.button<UserModalStyleProps>`
   background-color: transparent;
   font-size: ${props => (props.$isOpen ? '15px' : 0)};
   font-weight: 700;
+  white-space: nowrap;
   transition: all 0.5s;
 `;

--- a/src/components/common/Layout/Header/User/UserModal/index.tsx
+++ b/src/components/common/Layout/Header/User/UserModal/index.tsx
@@ -1,13 +1,21 @@
+import { useRef } from 'react';
 import styled from '@emotion/styled';
 
 import { UserModal, UserModalStyleProps } from '@/types/layout';
+import useOutsideClick from '@hooks/lib/useOutsideClick';
 import theme from '@styles/theme';
 
-const UserModal = ({ isOpen }: UserModal) => {
+const UserModal = ({ isOpen, setIsUserModalOpen }: UserModal) => {
   // HACK: cookie에서 사용자 정보 가져오기
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useOutsideClick(modalRef, setIsUserModalOpen);
 
   return (
-    <Modal $isOpen={isOpen}>
+    <Modal
+      $isOpen={isOpen}
+      ref={modalRef}
+    >
       <UserInformation>
         <Name $isOpen={isOpen}>김사장님</Name>
         <Email $isOpen={isOpen}>yanolja123@yanolja.com</Email>

--- a/src/components/common/Layout/Header/User/index.tsx
+++ b/src/components/common/Layout/Header/User/index.tsx
@@ -15,7 +15,10 @@ const User = () => {
         alt="사용자 프로필"
         onClick={() => setIsUserModalOpen(prev => !prev)}
       />
-      <UserModal isOpen={isUserModalOpen} />
+      <UserModal
+        isOpen={isUserModalOpen}
+        setIsUserModalOpen={setIsUserModalOpen}
+      />
     </>
   );
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /* lib hooks */
-export { default as useExample } from './lib/useExample';
+export { default as useOutsideClick } from './lib/useOutsideClick';
 
 /* quries hooks */
 export { default as useGetExample } from './queries/useGetExample';

--- a/src/hooks/lib/useExample.ts
+++ b/src/hooks/lib/useExample.ts
@@ -1,5 +1,0 @@
-const useExample = () => {
-  return '파일 컨벤션 사용 예시 문구';
-};
-
-export default useExample;

--- a/src/hooks/lib/useOutsideClick.ts
+++ b/src/hooks/lib/useOutsideClick.ts
@@ -1,0 +1,45 @@
+import { RefObject, useEffect } from 'react';
+
+const useOutsideClick = <T extends HTMLElement>(
+  ref: RefObject<T>,
+  setter: React.Dispatch<React.SetStateAction<boolean>>
+): void => {
+  const handleClickOutside = (e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
+      setter(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, setter]);
+};
+
+export default useOutsideClick;
+
+/* 
+
+사용 시기 : 모달 밖 영역 클릭 시 모달 창이 닫히는 기능 구현 시
+사용법 : 아래 예시 코드 참고
+
+import { useState, useRef } from 'react';
+import { useOutsideClick } from '@hooks';
+
+const YourComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const modalRef = useRef(null);
+
+  useOutsideClick(modalRef, setIsOpen);
+
+  // ...
+
+  return (
+    <div ref={modalRef}></div>
+  );
+};
+
+*/

--- a/src/hooks/lib/useOutsideClick.ts
+++ b/src/hooks/lib/useOutsideClick.ts
@@ -2,11 +2,11 @@ import { RefObject, useEffect } from 'react';
 
 const useOutsideClick = <T extends HTMLElement>(
   ref: RefObject<T>,
-  setter: React.Dispatch<React.SetStateAction<boolean>>
+  setter: () => void
 ): void => {
   const handleClickOutside = (e: MouseEvent) => {
     if (ref.current && !ref.current.contains(e.target as Node)) {
-      setter(false);
+      setter();
     }
   };
 
@@ -33,7 +33,7 @@ const YourComponent = () => {
   const [isOpen, setIsOpen] = useState(false);
   const modalRef = useRef(null);
 
-  useOutsideClick(modalRef, setIsOpen);
+  useOutsideClick(modalRef, () => setIsOpen(boolean));
 
   // ...
 

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -25,9 +25,10 @@ export type CustomNavLink = {
   $userPath?: string;
 };
 
-//User
+// User
 export type UserModal = {
   isOpen: boolean;
+  setIsUserModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export type UserModalStyleProps = {


### PR DESCRIPTION
close #54

## Description

<!-- 작업 내용을 적어주세요. -->

- [x] cookie에서 사용자 정보 가져와 렌더링하기
- [x] 모달 외 화면 클릭 시 닫힘 (공통 hook 생성)
- [x] 로그아웃 글자 깨짐 현상 (white-space: nowrap;)

## 유의할 점 및 ETC (Optional)

<!-- 팀원이 유의해야할 사항을 적어주세요. -->

모달 외 화면 클릭 시 닫하는 공통 hook을 생성하였습니다. (진주님께서 구현해주신 부분을 공통으로 빼주었습니다!)
hooks/lib/useOutsideClick.ts 에서 확인 가능합니다. (아래 주석에 사용법 작성해 두었습니다.)

## 스크린샷 (Optional)

<!-- Optional 내용이 없다면 지워주세요! -->

https://github.com/CoolPeace-yanolza/frontend/assets/101972330/c69d0112-3729-4826-9016-42e6bf7d5bc7


