### PR TITLE
[#67] 레이아웃 헤더 select 디자인 수정 (정산 페이지 select 사용, 모바일 화면 작업)

### DIFF
--- a/src/components/common/DashboardHeader/index.tsx
+++ b/src/components/common/DashboardHeader/index.tsx
@@ -27,7 +27,13 @@ const DashboardHeader = () => {
           누적 리포트
         </ReportPageNavigation>
       </MenuContainer>
-      <Button>쿠폰 등록하기</Button>
+      <Button
+        onClick={() => {
+          navigate('/coupons/register');
+        }}
+      >
+        쿠폰 등록하기
+      </Button>
     </Container>
   );
 };

--- a/src/components/common/Layout/Header/Select/index.tsx
+++ b/src/components/common/Layout/Header/Select/index.tsx
@@ -1,14 +1,14 @@
-import styled from '@emotion/styled';
-import theme from '@styles/theme';
-
+import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
+import styled from '@emotion/styled';
+import { Dropdown, DropdownProps } from 'semantic-ui-react';
+
 import { headerAccommodationState } from '@recoil/index';
 import useGetHeaderAccommodation from '@hooks/queries/useGetHeaderAccommodation';
-import { useEffect } from 'react';
+import theme from '@styles/theme';
 
 const Select = () => {
   const { data: selectList } = useGetHeaderAccommodation();
-
   const [headerAccommodation, setHeaderAccommodation] = useRecoilState(
     headerAccommodationState
   );
@@ -17,8 +17,11 @@ const Select = () => {
     setHeaderAccommodation(selectList[0]);
   }, []);
 
-  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectId = Number(e.target.value);
+  const handleSelect = (
+    _e: React.SyntheticEvent<HTMLElement>,
+    data: DropdownProps
+  ) => {
+    const selectId = Number(data.value);
 
     const selectAccommodation = selectList.find(
       select => select.id === selectId
@@ -28,83 +31,50 @@ const Select = () => {
   };
 
   return (
-    <Container>
-      <Accommodations
-        name="Accommodations"
-        onChange={handleSelect}
-        value={headerAccommodation.id}
-      >
-        {selectList.map(item => (
-          <Accommodation
-            value={item.id}
-            key={item.id}
-          >
-            {item.name}
-          </Accommodation>
-        ))}
-      </Accommodations>
-      <SelectButton></SelectButton>
-    </Container>
+    <StyledDropdown
+      selection
+      options={selectList.map(item => ({
+        key: item.id,
+        text: item.name,
+        value: item.id
+      }))}
+      onChange={handleSelect}
+      value={headerAccommodation.id}
+    />
   );
 };
 
 export default Select;
 
-const Container = styled.div`
-  position: relative;
-`;
+const StyledDropdown = styled(Dropdown)`
+  &.ui.dropdown {
+    min-width: 200px;
 
-const Accommodations = styled.select`
-  position: relative;
+    border-radius: 12px;
+    padding: 10px 20px;
 
-  width: 200px;
-  height: 40px;
+    display: flex;
+    align-items: center;
 
-  margin-right: 30px;
-  border: none;
-  border-radius: 12px;
-  padding: 10px 20px;
+    color: rgba(60, 60, 67, 0.6);
+    background-color: rgba(247, 248, 252, 1);
+    font-weight: 500;
 
-  font-weight: 500;
-
-  color: rgba(60, 60, 67, 0.6);
-  background-color: rgba(247, 248, 252, 1);
-  outline-color: ${theme.colors.brand};
-
-  appearance: none;
-
-  &::-ms-expand {
-    display: none;
+    .text {
+      color: rgba(60, 60, 67, 0.6);
+    }
   }
 
   ${theme.response.tablet} {
-    width: 150px;
-    height: 30px;
+    &.ui.dropdown {
+      min-width: 180px;
+      padding: 5px 15px;
 
-    margin-right: 0;
-    padding: 0 20px;
+      font-size: 12px;
+    }
 
-    font-size: 12px;
+    .text {
+      color: rgba(60, 60, 67, 0.6);
+    }
   }
-`;
-
-const Accommodation = styled.option`
-  position: absolute;
-  top: 0;
-  right: 0;
-`;
-
-const SelectButton = styled.div`
-  position: absolute;
-  top: 16px;
-  right: 45px;
-
-  width: 0;
-  height: 0;
-
-  border-style: solid;
-  border-width: 8px 5px 0 5px;
-  border-color: #9c9c9c transparent transparent transparent;
-
-  pointer-events: none;
 `;

--- a/src/components/common/Layout/Header/index.tsx
+++ b/src/components/common/Layout/Header/index.tsx
@@ -19,7 +19,7 @@ const Header = () => {
         />
       </LogoLink>
       <Buttons>
-        <div></div>
+        <MobileDiv></MobileDiv>
         <Select />
         <User />
       </Buttons>
@@ -45,6 +45,7 @@ const Container = styled.header`
   align-items: center;
 
   background-color: ${theme.colors.white};
+  z-index: 90;
 
   ${theme.response.tablet} {
     height: 65px;
@@ -73,12 +74,24 @@ const LogoIcon = styled.img`
 `;
 
 const Buttons = styled.div`
+  min-width: 300px;
+
   display: flex;
+  justify-content: space-between;
   align-items: center;
 
   ${theme.response.tablet} {
     width: 100%;
+  }
+`;
 
-    justify-content: space-between;
+const MobileDiv = styled.div`
+  display: none;
+
+  ${theme.response.tablet} {
+    width: 50px;
+    height: 50px;
+
+    display: block;
   }
 `;

--- a/src/components/common/Layout/Sidebar/Header/index.tsx
+++ b/src/components/common/Layout/Sidebar/Header/index.tsx
@@ -35,6 +35,7 @@ const Container = styled.div<SidebarOpen>`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 100;
 
   ${theme.response.tablet} {
     margin-left: 5px;


### PR DESCRIPTION
close #67 

## Description

<!-- 작업 내용을 적어주세요. -->

레이아웃 헤더 select 디자인을 아래 스크린샷과 같이 수정하였습니다.

## 스크린샷 (Optional)

<!-- Optional 내용이 없다면 지워주세요! -->

<img width="233" alt="image" src="https://github.com/CoolPeace-yanolza/frontend/assets/101972330/46e81553-63dc-4a0f-a42f-834e49d2fe9e">

