### PR TITLE
[#76] 대시보드 API 연동(2)

### DIFF
--- a/src/api/lib/getLocalCouponUsage.ts
+++ b/src/api/lib/getLocalCouponUsage.ts
@@ -1,14 +1,13 @@
 import { instance } from '..';
+import { LocalCouponUsageResult } from '@/types/dashboard';
 
-const getLocalCouponUsage = async (id: number) => {
-  try {
-    const response = await instance.get(
-      `v1/dashboards/${id}/coupons/local/count`
-    );
-    return response.data;
-  } catch (err) {
-    console.error(err);
-  }
+const getLocalCouponUsage = async (
+  id: number
+): Promise<LocalCouponUsageResult> => {
+  const response = await instance.get(
+    `v1/dashboards/${id}/coupons/local/count`
+  );
+  return response.data;
 };
 
 export default getLocalCouponUsage;

--- a/src/api/lib/getMonthReports.ts
+++ b/src/api/lib/getMonthReports.ts
@@ -1,12 +1,10 @@
 import { instance } from '..';
 
-const getMonthReports = async (id: number) => {
-  try {
-    const response = await instance.get(`v1/dashboards/${id}/reports/month`);
-    return response.data;
-  } catch (err) {
-    console.error(err);
-  }
+import { MonthReportsResults } from '@/types/dashboard';
+
+const getMonthReports = async (id: number): Promise<MonthReportsResults[]> => {
+  const response = await instance.get(`v1/dashboards/${id}/reports/month`);
+  return response.data;
 };
 
 export default getMonthReports;

--- a/src/api/lib/getMonthReports.ts
+++ b/src/api/lib/getMonthReports.ts
@@ -4,7 +4,7 @@ import { MonthReportsResults } from '@/types/dashboard';
 
 const getMonthReports = async (id: number): Promise<MonthReportsResults[]> => {
   const response = await instance.get(`v1/dashboards/${id}/reports/month`);
-  return response.data;
+  return response.data.monthly_data_responses;
 };
 
 export default getMonthReports;

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/CouponCounter/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/CouponCounter/index.tsx
@@ -1,13 +1,16 @@
 import styled from '@emotion/styled';
 
 import { CouponCounterProps, CouponCounterStyleProps } from '@/types/dashboard';
+import { getStatusToLocaleString } from '@utils/index';
 import theme from '@styles/theme';
 
 const CouponCounter = ({ type, result }: CouponCounterProps) => {
   return (
     <Container $type={type}>
       <Header>{type === 'download' ? '｜다운로드 수' : '｜사용완료 수'}</Header>
-      <ResultContainer $type={type}>{result}장</ResultContainer>
+      <ResultContainer $type={type}>
+        {getStatusToLocaleString(result)}장
+      </ResultContainer>
     </Container>
   );
 };
@@ -37,7 +40,7 @@ const Header = styled.div`
 
   align-self: flex-start;
 
-  font-size: 13.005px;
+  font-size: 13px;
   font-weight: 700;
 
   white-space: nowrap;
@@ -56,7 +59,7 @@ const ResultContainer = styled.div<CouponCounterStyleProps>`
   background-color: ${props =>
     props.$type === 'download' ? '#F7F8FC' : '#ffffff4d'};
 
-  font-size: 19px;
+  font-size: 18px;
   font-weight: 700;
 
   box-shadow: ${theme.shadow.medium};

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.error.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.error.tsx
@@ -16,11 +16,15 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
 
+  border-radius: 16px;
+
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 30px;
+
+  background-color: #fafafb;
 `;
 
 const Header = styled.div`

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.error.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.error.tsx
@@ -1,0 +1,33 @@
+import { FallbackProps } from 'react-error-boundary';
+import styled from '@emotion/styled';
+
+const ErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
+  return (
+    <Container>
+      <Header>다운로드 리포트 에러 발생</Header>
+      <ResetButton onClick={resetErrorBoundary}>다시시도</ResetButton>
+    </Container>
+  );
+};
+
+export default ErrorFallback;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+`;
+
+const Header = styled.div`
+  font-size: 20px;
+  font-weight: 700;
+`;
+
+const ResetButton = styled.button`
+  width: 50%;
+`;

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.loading.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.loading.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+const Loading = () => {
+  return (
+    <Container>
+      <TitleLoading />
+      <InnerContainer>
+        <StatusLoadingWrapper>
+          <StatusItemLoading />
+          <StatusItemLoading />
+        </StatusLoadingWrapper>
+        <MainContentLoading />
+      </InnerContainer>
+    </Container>
+  );
+};
+
+export default Loading;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  padding: 20px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const BaseSkeleton = styled(Skeleton)`
+  width: 100%;
+
+  margin: none;
+  padding: none;
+  border-radius: 12px;
+
+  background-color: #f2f4f5;
+`;
+
+const TitleLoading = styled(BaseSkeleton)`
+  width: 40%;
+  height: 30px;
+`;
+
+const InnerContainer = styled.div`
+  width: 100%;
+  height: 300px;
+
+  padding: 10px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+`;
+
+const StatusLoadingWrapper = styled.div`
+  width: 100%;
+
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+`;
+
+const StatusItemLoading = styled(BaseSkeleton)`
+  width: 130px;
+  height: 130px;
+
+  flex: 1;
+`;
+
+const MainContentLoading = styled(BaseSkeleton)`
+  width: 100%;
+  height: 150px;
+
+  flex: 1.5;
+`;

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.tsx
@@ -1,12 +1,18 @@
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
 
 import CouponCounter from './CouponCounter';
 import CouponRate from './CouponRate';
 import titleIcon from '@assets/icons/ic-dashboard-downloadReport.svg';
 import reloadIcon from '@assets/icons/ic-dashboard-reload.svg';
+import { headerAccommodationState } from '@recoil/index';
+import { useGetMonthReports } from '@hooks/queries/useGetMonthReports';
 
-//HACK : 해당 컴포넌트에서 서버상태값 전달
 const DownloadReport = () => {
+  const headerSelectedState = useRecoilValue(headerAccommodationState);
+  const { data } = useGetMonthReports(headerSelectedState.id);
+  const lastestData = data[data.length - 1];
+
   return (
     <Container>
       <Header>
@@ -23,15 +29,15 @@ const DownloadReport = () => {
         <CouponCounterSection>
           <CouponCounter
             type="download"
-            result={400}
+            result={lastestData.download_count}
           />
           <CouponCounter
             type="used"
-            result={200}
+            result={lastestData.used_count}
           />
         </CouponCounterSection>
         <CouponRateSection>
-          <CouponRate result={10} />
+          <CouponRate result={lastestData.conversion_rate * 0.1} />
         </CouponRateSection>
       </InnerContainer>
     </Container>

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/DownloadReport/index.tsx
@@ -6,7 +6,7 @@ import CouponRate from './CouponRate';
 import titleIcon from '@assets/icons/ic-dashboard-downloadReport.svg';
 import reloadIcon from '@assets/icons/ic-dashboard-reload.svg';
 import { headerAccommodationState } from '@recoil/index';
-import { useGetMonthReports } from '@hooks/queries/useGetMonthReports';
+import { useGetMonthReports } from '@hooks/index';
 
 const DownloadReport = () => {
   const headerSelectedState = useRecoilValue(headerAccommodationState);

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/graphOptions.ts
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/graphOptions.ts
@@ -27,7 +27,7 @@ const graphOptions: any = {
     y1: {
       position: 'left',
       beginAtZero: true,
-      max: 1200,
+
       grid: {
         display: false
       }

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.error.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.error.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import { FallbackProps } from 'react-error-boundary';
+
+const ErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
+  return (
+    <Container>
+      <Header>월별 차트 에러 발생</Header>
+      <ResetButton onClick={resetErrorBoundary}>다시시도</ResetButton>
+    </Container>
+  );
+};
+
+export default ErrorFallback;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+`;
+
+const Header = styled.div`
+  font-size: 20px;
+  font-weight: 700;
+`;
+
+const ResetButton = styled.button`
+  width: 50%;
+`;

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.error.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.error.tsx
@@ -16,11 +16,16 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
 
+  border-radius: 16px;
+
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 30px;
+  align-self: center;
+
+  background-color: #fafafb;
 `;
 
 const Header = styled.div`

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.loading.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.loading.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+const Loading = () => {
+  return (
+    <Container>
+      <TitleLoading />
+      <GraphLoading />
+    </Container>
+  );
+};
+
+export default Loading;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  padding: 20px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const BaseSkeleton = styled(Skeleton)`
+  width: 100%;
+
+  margin: none;
+  padding: none;
+  border-radius: 12px;
+
+  background-color: #f2f4f5;
+`;
+
+const TitleLoading = styled(BaseSkeleton)`
+  width: 40%;
+  height: 30px;
+`;
+
+const GraphLoading = styled(BaseSkeleton)`
+  width: 100%;
+  height: 340px;
+`;

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.tsx
@@ -20,7 +20,7 @@ import { GraphHeaderTag } from '@/types/dashboard';
 import graphOptions from './graphOptions';
 import { getUpdatedDate } from '@utils/index';
 import { headerAccommodationState } from '@recoil/index';
-import { useGetMonthReports } from '@hooks/queries/useGetMonthReports';
+import { useGetMonthReports } from '@hooks/index';
 
 ChartJS.register(
   LinearScale,

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/GraphContainer/index.tsx
@@ -14,10 +14,13 @@ import {
   BarController
 } from 'chart.js';
 import { Chart } from 'react-chartjs-2';
+import { useRecoilValue } from 'recoil';
 
 import { GraphHeaderTag } from '@/types/dashboard';
 import graphOptions from './graphOptions';
 import { getUpdatedDate } from '@utils/index';
+import { headerAccommodationState } from '@recoil/index';
+import { useGetMonthReports } from '@hooks/queries/useGetMonthReports';
 
 ChartJS.register(
   LinearScale,
@@ -34,69 +37,71 @@ ChartJS.register(
 
 //HACK: 그래프 데이터 렌더링에 대한 테스트파일입니다. 실제 기능 구현에서는 해당 파일 다소 변경될 것 같습니다.
 
-const labels = ['1월', '2월', '3월', '4월', '5월', '6월'];
-
-export const barGraphData = {
-  labels,
-  datasets: [
-    {
-      type: 'line' as const,
-      label: '전환율(%)',
-      borderColor: '#FFADC8',
-      backgroundColor: '#FFADC8',
-      borderWidth: 2,
-      data: [10, 20, 10, 40, 30, 60, 10],
-      yAxisID: 'y2'
-    },
-    {
-      type: 'bar' as const,
-      label: '쿠폰 다운로드',
-      data: [600, 500, 400, 500, 600, 800, 800],
-      backgroundColor: '#3182F6',
-      borderRadius: 5,
-      yAxisID: 'y1'
-    },
-
-    {
-      type: 'bar' as const,
-      label: '쿠폰 사용완료',
-      data: [300, 400, 200, 200, 400, 600, 700],
-      backgroundColor: '#FF3478',
-      borderRadius: 5,
-      yAxisID: 'y1'
-    }
-  ]
-};
-
-export const lineGraphData = {
-  labels,
-  datasets: [
-    {
-      fill: true,
-      label: '쿠폰매출',
-      data: [300, 400, 200, 200, 400, 600, 700],
-      borderWidth: 1,
-      borderColor: '#3182F6',
-      backgroundColor: '#A7CBFF',
-      yAxisID: 'y1'
-    },
-
-    {
-      fill: true,
-      label: '전체매출',
-      data: [600, 500, 400, 500, 600, 800, 800],
-      borderWidth: 1,
-      borderColor: '#FF3478',
-      backgroundColor: '#FFC1D6',
-      yAxisID: 'y1'
-    }
-  ]
-};
-
 //HACK 추후 utils에 적절한 폴더 생기면 옮길 예정
 
 const GraphContainer = () => {
+  const headerSelectedState = useRecoilValue(headerAccommodationState);
+  const { data } = useGetMonthReports(headerSelectedState.id);
   const [isIncomeGraph, setisIncomeGraph] = useState(true);
+
+  const barGraphData = {
+    labels: data.map(data => `${data.statistics_month}월`),
+    datasets: [
+      {
+        type: 'line' as const,
+        label: '전환율(%)',
+        borderColor: '#FFADC8',
+        backgroundColor: '#FFADC8',
+        borderWidth: 2,
+        data: data.map(data => data.conversion_rate),
+        yAxisID: 'y2'
+      },
+      {
+        type: 'bar' as const,
+        label: '쿠폰 다운로드',
+        data: data.map(data => data.download_count),
+        backgroundColor: '#3182F6',
+        borderRadius: 7,
+        yAxisID: 'y1',
+        barPercentage: 0.8
+      },
+
+      {
+        type: 'bar' as const,
+        label: '쿠폰 사용완료',
+        data: data.map(data => data.used_count),
+        backgroundColor: '#FF3478',
+        borderRadius: 7,
+        yAxisID: 'y1',
+        barPercentage: 0.8
+      }
+    ]
+  };
+
+  const lineGraphData = {
+    labels: data.map(data => `${data.statistics_month}월`),
+    datasets: [
+      {
+        fill: true,
+        label: '쿠폰매출',
+        data: data.map(data => data.coupon_total_sales),
+        borderWidth: 1,
+        borderColor: '#3182F6',
+        backgroundColor: '#A7CBFF',
+        yAxisID: 'y1'
+      },
+
+      {
+        fill: true,
+        label: '전체매출',
+        data: data.map(data => data.total_sales),
+        borderWidth: 1,
+        borderColor: '#FF3478',
+        backgroundColor: '#FFC1D6',
+        yAxisID: 'y1'
+      }
+    ]
+  };
 
   return (
     <Container>

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/index.tsx
@@ -7,7 +7,9 @@ import { DashboardHeader } from '@components/common';
 const GraphContainer = React.lazy(() => import('./GraphContainer'));
 import GraphContainerErrorFallback from './GraphContainer/index.error';
 import GraphContainerLoading from './GraphContainer/index.loading';
-import DownloadReport from './DownloadReport';
+const DownloadReport = React.lazy(() => import('./DownloadReport'));
+import DownloadReportErrorFallback from './DownloadReport/index.error';
+import DownloadReportLoading from './DownloadReport/index.loading';
 
 const GraphSection = () => {
   const { reset } = useQueryErrorResetBoundary();
@@ -27,7 +29,14 @@ const GraphSection = () => {
           </ErrorBoundary>
         </LeftSection>
         <RightSection>
-          <DownloadReport />
+          <ErrorBoundary
+            onReset={reset}
+            fallbackRender={DownloadReportErrorFallback}
+          >
+            <Suspense fallback={<DownloadReportLoading />}>
+              <DownloadReport />
+            </Suspense>
+          </ErrorBoundary>
         </RightSection>
       </InnerContainer>
     </Container>

--- a/src/components/Dashboard/DashboardLeftSection/GraphSection/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/GraphSection/index.tsx
@@ -1,16 +1,30 @@
 import styled from '@emotion/styled';
+import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 
 import { DashboardHeader } from '@components/common';
-import GraphContainer from './GraphContainer';
+const GraphContainer = React.lazy(() => import('./GraphContainer'));
+import GraphContainerErrorFallback from './GraphContainer/index.error';
+import GraphContainerLoading from './GraphContainer/index.loading';
 import DownloadReport from './DownloadReport';
 
 const GraphSection = () => {
+  const { reset } = useQueryErrorResetBoundary();
+
   return (
     <Container>
       <DashboardHeader />
       <InnerContainer>
         <LeftSection>
-          <GraphContainer />
+          <ErrorBoundary
+            onReset={reset}
+            fallbackRender={GraphContainerErrorFallback}
+          >
+            <Suspense fallback={<GraphContainerLoading />}>
+              <GraphContainer />
+            </Suspense>
+          </ErrorBoundary>
         </LeftSection>
         <RightSection>
           <DownloadReport />

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.error.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.error.tsx
@@ -16,6 +16,8 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
 
+  border-radius: 16px;
+
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -23,6 +25,8 @@ const Container = styled.div`
   gap: 30px;
 
   color: #404446;
+
+  background-color: #fafafb;
 `;
 
 const ErrorMessage = styled.span`

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.error.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.error.tsx
@@ -1,0 +1,37 @@
+import { FallbackProps } from 'react-error-boundary';
+import styled from '@emotion/styled';
+
+const ErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
+  return (
+    <Container>
+      <ErrorMessage>지역 쿠폰 현황 에러 발생</ErrorMessage>
+      <RetryButton onClick={resetErrorBoundary}>다시 시도</RetryButton>
+    </Container>
+  );
+};
+
+export default ErrorFallback;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+
+  color: #404446;
+`;
+
+const ErrorMessage = styled.span`
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.4;
+`;
+
+const RetryButton = styled.button`
+  width: 50%;
+`;

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.loading.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.loading.tsx
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled';
+import Skeleton from 'react-loading-skeleton';
+import 'react-loading-skeleton/dist/skeleton.css';
+
+const Loading = () => {
+  return (
+    <Container>
+      <Header>
+        <TitleLoading />
+        <SubTitleLoading />
+      </Header>
+      <InnerContainer />
+    </Container>
+  );
+};
+
+export default Loading;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  gap: 10px;
+`;
+
+const BaseSkeleton = styled(Skeleton)`
+  width: 100%;
+
+  border-radius: 16px;
+
+  background-color: #f2f4f5;
+`;
+
+const Header = styled.div`
+  width: 100%;
+  height: 30%;
+
+  margin: 0;
+  padding: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const TitleLoading = styled(BaseSkeleton)`
+  width: 80%;
+  height: 30px;
+
+  margin: 0;
+  padding: 0;
+`;
+
+const SubTitleLoading = styled(BaseSkeleton)`
+  width: 40%;
+  height: 20px;
+
+  margin: 0;
+  padding: 0;
+
+  display: flex;
+  align-items: center;
+`;
+
+const InnerContainer = styled(BaseSkeleton)`
+  height: 180px;
+`;

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
 
+import { useGetLocalCouponUsage } from '@hooks/queries/useGetLocalCouponUsage';
+import { headerAccommodationState } from '@recoil/index';
 import reloadIcon from '@assets/icons/ic-dashboard-reload.svg';
 import locationIcon from '@assets/icons/ic-dashboard-location.svg';
 import bigLocationIcon from '@assets/icons/ic-dashboard-bigLocation.svg';
@@ -7,6 +10,8 @@ import gpsIcon from '@assets/icons/ic-dashboard-gps.svg';
 import '@components/Dashboard/dashboardKeyframes.css';
 
 const LocalCouponUsage = () => {
+  const headerSelectedState = useRecoilValue(headerAccommodationState);
+  const { data } = useGetLocalCouponUsage(headerSelectedState.id);
   return (
     <Container>
       <Header>
@@ -17,7 +22,7 @@ const LocalCouponUsage = () => {
             src={locationIcon}
             alt="장소"
           />
-          종로구 기준
+          {data.address} 기준
         </Location>
       </Header>
       <UpdateAlarm>
@@ -38,7 +43,7 @@ const LocalCouponUsage = () => {
         <CouponUsage>
           <span>현재 내 숙소 주위의 사장님들이</span>
           <MainInformation>
-            평균 {8}종 이상의 쿠폰을 사용하고 있어요!
+            평균 {data.coupon_avg}종 이상의 쿠폰을 사용하고 있어요!
           </MainInformation>
           <BigLocationIcon
             src={bigLocationIcon}

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 
-import { useGetLocalCouponUsage } from '@hooks/queries/useGetLocalCouponUsage';
+import { useGetLocalCouponUsage } from '@hooks/index';
 import { headerAccommodationState } from '@recoil/index';
 import reloadIcon from '@assets/icons/ic-dashboard-reload.svg';
 import locationIcon from '@assets/icons/ic-dashboard-location.svg';

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/LocalCouponUsage/index.tsx
@@ -161,6 +161,8 @@ const CouponUsage = styled.div`
 `;
 
 const MainInformation = styled.div`
+  padding-top: 1px;
+
   color: #202325;
   font-size: 19px;
   font-weight: 700;

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/Top3Coupons/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/Top3Coupons/index.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import arrowIcon from '@assets/icons/ic-dashboard-arrow.svg';
 import RankingBox from './RankingBox';
-import { useGetCouponRanking } from '@hooks/queries/useGetCouponRanking';
+import { useGetCouponRanking } from '@hooks/index';
 import { headerAccommodationState } from '@recoil/index';
 
 const LocalTop3Coupons = () => {

--- a/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/index.tsx
+++ b/src/components/Dashboard/DashboardLeftSection/LocalInformationSection/index.tsx
@@ -3,10 +3,12 @@ import styled from '@emotion/styled';
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
 
-import LocalCouponUsage from './LocalCouponUsage';
 const LocalTop3Coupons = React.lazy(() => import('./Top3Coupons'));
 import Top3CouponErrorFallback from './Top3Coupons/index.error';
-import Top3CouponRanking from './Top3Coupons/index.loading';
+import Top3CouponRankingLoading from './Top3Coupons/index.loading';
+const LocalCouponUsage = React.lazy(() => import('./LocalCouponUsage'));
+import LocalUsageErrorFallback from './LocalCouponUsage/index.error';
+import LocalUsageLoading from './LocalCouponUsage/index.loading';
 
 const LocalInformationSection = () => {
   const { reset } = useQueryErrorResetBoundary();
@@ -14,14 +16,21 @@ const LocalInformationSection = () => {
   return (
     <Container>
       <LeftSection>
-        <LocalCouponUsage />
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={LocalUsageErrorFallback}
+        >
+          <Suspense fallback={<LocalUsageLoading />}>
+            <LocalCouponUsage />
+          </Suspense>
+        </ErrorBoundary>
       </LeftSection>
       <RightSection>
         <ErrorBoundary
           onReset={reset}
           fallbackRender={Top3CouponErrorFallback}
         >
-          <Suspense fallback={<Top3CouponRanking />}>
+          <Suspense fallback={<Top3CouponRankingLoading />}>
             <LocalTop3Coupons />
           </Suspense>
         </ErrorBoundary>

--- a/src/components/Dashboard/DashboardRightSection/CouponStatusSection/index.tsx
+++ b/src/components/Dashboard/DashboardRightSection/CouponStatusSection/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 
 import StatusItem from './StatusItem';
-import { useGetMonthStatus } from '@hooks/queries/useGetMonthStatus';
+import { useGetMonthStatus } from '@hooks/index';
 import { getStatusToLocaleString } from '@utils/index';
 import { headerAccommodationState } from '@recoil/index';
 

--- a/src/components/Dashboard/DashboardRightSection/DailyReportSection/index.tsx
+++ b/src/components/Dashboard/DashboardRightSection/DailyReportSection/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
 
 import GetMatchedReport from './GetMatchedReport';
-import { useGetDailyReport } from '@hooks/queries/useGetDailyReport';
+import { useGetDailyReport } from '@hooks/index';
 import { headerAccommodationState } from '@recoil/index';
 
 const DailyReportSection = () => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,8 @@ export { default as useOutsideClick } from './lib/useOutsideClick';
 /* quries hooks */
 export { default as useGetTotalReport } from './queries/useGetTotalReport';
 export { default as useGetYearReport } from './queries/useGetYearReport';
+export { default as useGetCouponRanking } from './queries/useGetCouponRanking';
+export { default as useGetDailyReport } from './queries/useGetDailyReport';
+export { default as useGetLocalCouponUsage } from './queries/useGetLocalCouponUsage';
+export { default as useGetMonthReports } from './queries/useGetMonthReports';
+export { default as useGetMonthStatus } from './queries/useGetMonthStatus';

--- a/src/hooks/queries/useGetCouponRanking.ts
+++ b/src/hooks/queries/useGetCouponRanking.ts
@@ -2,9 +2,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getCouponRanking } from 'src/api';
 
-export const useGetCouponRanking = (accommodation_id: number) => {
+const useGetCouponRanking = (accommodation_id: number) => {
   return useSuspenseQuery({
     queryKey: ['CouponRanking', accommodation_id],
     queryFn: () => getCouponRanking(accommodation_id)
   });
 };
+
+export default useGetCouponRanking;

--- a/src/hooks/queries/useGetDailyReport.ts
+++ b/src/hooks/queries/useGetDailyReport.ts
@@ -2,9 +2,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getDailyReport } from 'src/api';
 
-export const useGetDailyReport = (accommodation_id: number) => {
+const useGetDailyReport = (accommodation_id: number) => {
   return useSuspenseQuery({
     queryKey: ['DailyReport', accommodation_id],
     queryFn: () => getDailyReport(accommodation_id)
   });
 };
+
+export default useGetDailyReport;

--- a/src/hooks/queries/useGetLocalCouponUsage.ts
+++ b/src/hooks/queries/useGetLocalCouponUsage.ts
@@ -2,9 +2,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getLocalCouponUsage } from 'src/api';
 
-export const useGetLocalCouponUsage = (accommodation_id: number) => {
+const useGetLocalCouponUsage = (accommodation_id: number) => {
   return useSuspenseQuery({
     queryKey: ['LocalCouponUsage', accommodation_id],
     queryFn: () => getLocalCouponUsage(accommodation_id)
   });
 };
+
+export default useGetLocalCouponUsage;

--- a/src/hooks/queries/useGetLocalCouponUsage.tsx
+++ b/src/hooks/queries/useGetLocalCouponUsage.tsx
@@ -1,0 +1,10 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getLocalCouponUsage } from 'src/api';
+
+export const useGetLocalCouponUsage = (accommodation_id: number) => {
+  return useSuspenseQuery({
+    queryKey: ['LocalCouponUsage', accommodation_id],
+    queryFn: () => getLocalCouponUsage(accommodation_id)
+  });
+};

--- a/src/hooks/queries/useGetMonthReports.ts
+++ b/src/hooks/queries/useGetMonthReports.ts
@@ -2,9 +2,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getMonthReports } from 'src/api';
 
-export const useGetMonthReports = (accommodation_id: number) => {
+const useGetMonthReports = (accommodation_id: number) => {
   return useSuspenseQuery({
     queryKey: ['MonthReports', accommodation_id],
     queryFn: () => getMonthReports(accommodation_id)
   });
 };
+
+export default useGetMonthReports;

--- a/src/hooks/queries/useGetMonthReports.tsx
+++ b/src/hooks/queries/useGetMonthReports.tsx
@@ -1,0 +1,10 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMonthReports } from 'src/api';
+
+export const useGetMonthReports = (accommodation_id: number) => {
+  return useSuspenseQuery({
+    queryKey: ['MonthReports', accommodation_id],
+    queryFn: () => getMonthReports(accommodation_id)
+  });
+};

--- a/src/hooks/queries/useGetMonthStatus.ts
+++ b/src/hooks/queries/useGetMonthStatus.ts
@@ -3,9 +3,11 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getMonthStatus } from 'src/api';
 import { CouponStatusResults } from '@/types/dashboard';
 
-export const useGetMonthStatus = (accommodation_id: number) => {
+const useGetMonthStatus = (accommodation_id: number) => {
   return useSuspenseQuery<CouponStatusResults>({
     queryKey: ['MonthStatus', accommodation_id],
     queryFn: () => getMonthStatus(accommodation_id)
   });
 };
+
+export default useGetMonthStatus;

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -67,6 +67,11 @@ export type CouponRankingResult = {
   third_coupon_title: string;
 };
 
+export type LocalCouponUsageResult = {
+  address: string;
+  coupon_avg: string;
+};
+
 // DailyReport
 
 export type DailyReportResult = {

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -9,6 +9,7 @@ export type GraphHeaderTag = Pick<HeaderTagStyleProps, '$active'>;
 export type MonthReportsResults = {
   statistics_year: number;
   statistics_month: number;
+  total_sales: number;
   coupon_total_sales: number;
   download_count: number;
   used_count: number;


### PR DESCRIPTION
close #76 

## Description

대시보드 API 연동 완료했습니다!

## 유의할 점 및 ETC (Optional)

- 에러 바운더리 디자인에 따라, 대시보드 쪽에서는 공동 ErrorFallback파일을 사용할 수도 있을 것 같습니다! 
   - 현재는 모두 각각 쓰고 있습니다!
- 대부분 styled 코드입니다!

## 스크린샷 (Optional)

### 1. 구현 섹션

<img width="1421" alt="스크린샷 2024-01-23 오전 2 44 41" src="https://github.com/CoolPeace-yanolza/frontend/assets/83493231/7a26302f-c9ad-4fff-bea5-94f56eb78161">


### 2. 로딩 화면


https://github.com/CoolPeace-yanolza/frontend/assets/83493231/6d83f546-06d1-4594-970b-b65c6d687339

