### PR TITLE
[#114] 정산 요약 내역 엑셀 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "semantic-ui-css": "^2.5.0",
         "semantic-ui-react": "^2.1.5",
         "styled-components": "^6.1.8",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "xlsx-js-style": "^1.2.0"
       },
       "devDependencies": {
         "@swc/core": "^1.3.102",
@@ -3657,6 +3658,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4234,6 +4240,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -4313,6 +4327,11 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.3.11.tgz",
+      "integrity": "sha512-Rr5QlUeGN1mbOHlaqcSYMKVpPbgLy0AWT/W0EHxA6NGI12yO1jpoui2zBBvU2G824ltM6Ut8BFgfHSBGfkmS0A=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -6491,6 +6510,17 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "bin": {
+        "printj": "bin/printj.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -7653,6 +7683,64 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xlsx-js-style": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xlsx-js-style/-/xlsx-js-style-1.2.0.tgz",
+      "integrity": "sha512-DDT4FXFSWfT4DXMSok/m3TvmP1gvO3dn0Eu/c+eXHW5Kzmp7IczNkxg/iEPnImbG9X0Vb8QhROda5eatSR/97Q==",
+      "dependencies": {
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.14.0",
+        "commander": "~2.17.1",
+        "crc-32": "~1.2.0",
+        "exit-on-epipe": "~1.0.1",
+        "fflate": "^0.3.8",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx-js-style/node_modules/adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
+      "dependencies": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      },
+      "bin": {
+        "adler32": "bin/adler32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx-js-style/node_modules/codepage": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha512-iz3zJLhlrg37/gYRWgEPkaFTtzmnEv1h+r7NgZum2lFElYQPi0/5bnmuDfODHxfp0INEfnRqyfyeIJDbb7ahRw==",
+      "dependencies": {
+        "commander": "~2.14.1",
+        "exit-on-epipe": "~1.0.1"
+      },
+      "bin": {
+        "codepage": "bin/codepage.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx-js-style/node_modules/codepage/node_modules/commander": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "semantic-ui-css": "^2.5.0",
     "semantic-ui-react": "^2.1.5",
     "styled-components": "^6.1.8",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "xlsx-js-style": "^1.2.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.102",

--- a/src/api/lib/getSettlements.ts
+++ b/src/api/lib/getSettlements.ts
@@ -2,7 +2,7 @@ import { SettlementedList } from '@/types/settlements';
 import { instance } from '..';
 
 const getSettlements = async (
-  accommodationId: number,
+  accommodation_id: number,
   start?: string,
   end?: string,
   order?: string,
@@ -25,7 +25,7 @@ const getSettlements = async (
   };
 
   try {
-    const response = await instance.get(`/v1/settlements/${accommodationId}`, {
+    const response = await instance.get(`/v1/settlements/${accommodation_id}`, {
       params,
     });
 

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/SettlementsTable/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/SettlementsTable/index.tsx
@@ -49,7 +49,7 @@ const SettlementsTable = ({ data, pageStartNumber }: SettlementsTableProps) => {
             <Row key={index} isLast={false}>
               {keys.map((key) => (
                  <DataElement key={key}>
-                  <MobileDataElement>{key}</MobileDataElement>
+                  <MobileDataElement>{keyToLabelMap[key]}</MobileDataElement>
                   <MobileData>
                     {key === 'NO' ? pageStartNumber - index : null}
                     {key === 'coupon_count' ? `${row[key].toLocaleString()}건` : null}

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/SettlementsTable/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/SettlementsTable/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { SettlementedItem, SettlementsTableProps } from '@/types/settlements';
 import settlementsFrame from '@assets/icons/settlements-data-frame.svg'; 
 import theme from '@styles/theme';
-import keyToLabelMap from 'src/constants/lib/SETTLEMENTS_TABLE_KEY';
+import { SETTLEMENTS_TABLE_KEY } from 'src/constants';
 
 const SettlementsTable = ({ data, pageStartNumber }: SettlementsTableProps) => {
   
@@ -24,7 +24,7 @@ const SettlementsTable = ({ data, pageStartNumber }: SettlementsTableProps) => {
       <Container>
         <Header>
           {keys.map((key, index) => (
-            <KeyElement key={index}>{keyToLabelMap[key]}</KeyElement>
+            <KeyElement key={index}>{SETTLEMENTS_TABLE_KEY[key]}</KeyElement>
           ))}
         </Header>
         <FrameContainer>
@@ -40,7 +40,7 @@ const SettlementsTable = ({ data, pageStartNumber }: SettlementsTableProps) => {
     <Container>
       <Header>
         {keys.map((key, index) => (
-          <KeyElement key={index}>{keyToLabelMap[key]}</KeyElement>
+          <KeyElement key={index}>{SETTLEMENTS_TABLE_KEY[key]}</KeyElement>
         ))}
       </Header>
       <FrameContainer>
@@ -49,7 +49,7 @@ const SettlementsTable = ({ data, pageStartNumber }: SettlementsTableProps) => {
             <Row key={index} isLast={false}>
               {keys.map((key) => (
                  <DataElement key={key}>
-                  <MobileDataElement>{keyToLabelMap[key]}</MobileDataElement>
+                  <MobileDataElement>{SETTLEMENTS_TABLE_KEY[key]}</MobileDataElement>
                   <MobileData>
                     {key === 'NO' ? pageStartNumber - index : null}
                     {key === 'coupon_count' ? `${row[key].toLocaleString()}건` : null}

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.error.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.error.tsx
@@ -27,11 +27,11 @@ const ErrorFallback = ({ resetErrorBoundary }: FallbackProps) => {
 export default ErrorFallback;
 
 const Container = styled.div`
-  height: 619.13px;
+  height: 554px;
 
   margin-left: 43px;
   margin-right: 43px;
-  margin-top: 20px;
+  margin-top: 110px;
   padding: 30px 15px;
   border-radius: 20px;
 

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.loading.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.loading.tsx
@@ -18,11 +18,11 @@ const Loading = () => {
 export default Loading;
 
 const Container = styled.div`
-  height: 619.13px;
+  height: 554px;
 
   margin-left: 43px;
   margin-right: 43px;
-  margin-top: 20px;
+  margin-top: 110px;
   padding: 30px 15px;
   border-radius: 20px;
 

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -99,7 +99,7 @@ const Settlemented = () => {
     try {
       const response = await getSettlements(
         accommodation.id,
-        startDate ? startDate.toISOString().split('T')[0] : '2000-01-01',
+        startDate ? startDate.toISOString().split('T')[0] : getCurrentYearStartDate(),
         endDate ? endDate.toISOString().split('T')[0] : getCurrentYearEndDate(),
         orderBy,
         0,

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -113,6 +113,8 @@ const handleDownloadExcel = async () => {
 
     const workBook = XLSX.utils.book_new();
     const workSheet = XLSX.utils.json_to_sheet(allData);
+
+    workSheet['!cols'] = [{wch:12}, {wch:12}, {wch:25}, {wch:5}, {wch:12}, {wch:12}, {wch:12}, {wch:12}];
     
     XLSX.utils.book_append_sheet(workBook, workSheet, "Sheet1");
     XLSX.writeFile(workBook, "SettlementedDownload.xlsx");

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -455,6 +455,8 @@ const StyledDropdown = styled(Dropdown)`
     }
 
     .text {
+      position: relative;
+      top: -1.5px;
       max-height: 30px;
 
       font-size: 11px;

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import 'semantic-ui-css/semantic.min.css';
 import { Dropdown, DropdownProps } from 'semantic-ui-react';
 import { useState, useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import XLSX from 'xlsx-js-style';
 
 import SettlementsTable from './SettlementsTable';
@@ -16,6 +16,7 @@ import { getCurrentYearStartDate, getCurrentYearEndDate } from '@utils/index';
 import { convertKeysToKorean } from '@utils/index';
 import { SORT_OPTION } from 'src/constants';
 import theme from '@styles/theme';
+import { currentPageState } from '@recoil/index';
 
 const Settlemented = () => {
 
@@ -23,7 +24,7 @@ const Settlemented = () => {
   const [, setSortOrder] = useState('couponDateDesc');
   const [orderBy, setOrderBy] = useState('COUPON_USE_DATE');
   const [currentData, setCurrentData] = useState<SettlementedItem[]>([]);
-  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [currentPage, setCurrentPage] = useRecoilState(currentPageState);
 
   const accommodation = useRecoilValue(headerAccommodationState);
 

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -116,8 +116,6 @@ const Settlemented = () => {
         [''],
         ['', '', '', '', '', '', ''],
         ['', '', '', '', '', '', ''], 
-        [''],
-        ['']
       ];
 
       
@@ -137,7 +135,7 @@ const Settlemented = () => {
         v: '쿠폰 정산',
         s: {
           font: {sz: 16}, 
-          fill: { fgColor: { rgb: "FF87CEFA" } },
+          fill: { fgColor: { rgb: "809FFF" } },
           alignment: {horizontal: 'right'} 
         }
       };
@@ -146,7 +144,7 @@ const Settlemented = () => {
         v: '내역 리스트',
         s: {
           font: {sz: 16},
-          fill: { fgColor: { rgb: "FF87CEFA" } }, 
+          fill: { fgColor: { rgb: "809FFF" } }, 
           alignment: {horizontal: 'left'} 
         }
       };

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import 'semantic-ui-css/semantic.min.css';
 import { Dropdown, DropdownProps } from 'semantic-ui-react';
 import { useState, useEffect } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import XLSX from 'xlsx-js-style';
 
 import SettlementsTable from './SettlementsTable';

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -14,6 +14,7 @@ import { settlementsDateState } from '@recoil/atoms/settlemented';
 import headerAccommodationState from '@recoil/atoms/headerAccommodationState';
 import { getCurrentYearStartDate, getCurrentYearEndDate } from '@utils/index';
 import { convertKeysToKorean } from '@utils/index';
+import { SORT_OPTION } from 'src/constants';
 import theme from '@styles/theme';
 
 const Settlemented = () => {
@@ -28,14 +29,7 @@ const Settlemented = () => {
 
   const itemsPerPage = 10;
 
-  const sortOptions = [
-    { key: 'couponDateDesc', text: '쿠폰 사용일 최근 순', value: 'couponDateDesc' },
-    { key: 'dateDesc', text: '정산 완료일 최근 순', value: 'dateDesc' },
-    { key: 'amountDesc', text: '정산금액 많은 순', value: 'amountDesc' },
-    { key: 'usageCountDesc', text: '사용건 많은 순', value: 'usageCountDesc' },
-  ];
-
-  const defaultOption = sortOptions.find(option => option.value === 'couponDateDesc');
+  const defaultOption = SORT_OPTION.find(option => option.value === 'couponDateDesc');
 
   const handleSortChange = (_e: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => {
     setSortOrder(data.value as string);
@@ -138,7 +132,7 @@ const handleDownloadExcel = async () => {
             fluid
             selection
             defaultValue={defaultOption?.value}
-            options={sortOptions}
+            options={SORT_OPTION}
             onChange={handleSortChange}
           />
           <ExcelDownload>

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/Settlemented/index.tsx
@@ -13,6 +13,7 @@ import { SettlementedItem } from '@/types/settlements';
 import { settlementsDateState } from '@recoil/atoms/settlemented';
 import headerAccommodationState from '@recoil/atoms/headerAccommodationState';
 import { getCurrentYearStartDate, getCurrentYearEndDate } from '@utils/index';
+import { convertKeysToKorean } from '@utils/index';
 import theme from '@styles/theme';
 
 const Settlemented = () => {
@@ -95,32 +96,31 @@ const Settlemented = () => {
     return totalItems - (currentPage - 1) * itemsPerPage;
   };
 
-  const handleDownloadExcel = async () => {
-    try {
-      const response = await getSettlements(
-        accommodation.id,
-        startDate ? startDate.toISOString().split('T')[0] : getCurrentYearStartDate(),
-        endDate ? endDate.toISOString().split('T')[0] : getCurrentYearEndDate(),
-        orderBy,
-        0,
-        totalItems
-      );
+const handleDownloadExcel = async () => {
+  try {
+    const response = await getSettlements(
+      accommodation.id,
+      startDate ? startDate.toISOString().split('T')[0] : getCurrentYearStartDate(),
+      endDate ? endDate.toISOString().split('T')[0] : getCurrentYearEndDate(),
+      orderBy,
+      0,
+      totalItems
+    );
 
-      const allData = response.settlement_responses.map((data: SettlementedItem, index: number) => ({
-        ...data,
-        NO: index + 1,
-      }));
-  
-      const workBook = XLSX.utils.book_new();
-      const workSheet = XLSX.utils.json_to_sheet(allData);
-  
-      XLSX.utils.book_append_sheet(workBook, workSheet, "Sheet1");
-      XLSX.writeFile(workBook, "SettlementedDownload.xlsx");
-    } catch (error) {
-      console.error('Error fetching all settlements data for download:', error);
-    }
-  };
-  
+    const allData = response.settlement_responses.map((data: SettlementedItem) => {
+      return convertKeysToKorean(data);
+    });
+
+    const workBook = XLSX.utils.book_new();
+    const workSheet = XLSX.utils.json_to_sheet(allData);
+    
+    XLSX.utils.book_append_sheet(workBook, workSheet, "Sheet1");
+    XLSX.writeFile(workBook, "SettlementedDownload.xlsx");
+  } catch (error) {
+    console.error('Error fetching all settlements data for download:', error);
+  }
+};
+
   useEffect(() => {
     setCurrentPage(1);
   }, [accommodation]);

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/SettlementsHeader/SettlementsPopup/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/SettlementsHeader/SettlementsPopup/index.tsx
@@ -15,7 +15,7 @@ const SettlementsPopup: React.FC<SettlementsPopupProps> = ({ isOpen, onClose }) 
             <p><strong>⦁ 쿠폰 번호</strong>는 쿠폰을 등록하면 자동으로 발행되는 관리목적의 번호입니다.</p>
             <p><strong>⦁ 관리 쿠폰명</strong>은 사장님께서 직접 설정한 쿠폰명입니다.</p>
             <p><strong>⦁ 사용 건수</strong>는 쿠폰 적용일에 고객들이 쿠폰을 사용한 건 수입니다.</p>
-            <p><strong>⦁ 구폰 적용일</strong>은 사용자가 쿠폰을 적용하여 결제(예약)를 한 날입니다.</p>
+            <p><strong>⦁ 쿠폰 적용일</strong>은 사용자가 쿠폰을 적용하여 결제(예약)를 한 날입니다.</p>
             <p><strong>⦁ 정산 완료일</strong>은 정산이 완료된 날로 매월 1일 (영업일 기준)입니다.</p>
         </PopupContentHeader>
         <PopupContentMiddle>

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/index.tsx
@@ -3,7 +3,7 @@ import { Suspense, forwardRef, useState } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { ko } from 'date-fns/locale';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { createGlobalStyle } from 'styled-components';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
@@ -18,10 +18,13 @@ import CalendarIcon from '@assets/icons/calendar-outline.svg';
 import theme from '@styles/theme';
 import Loading from './Settlemented/index.loading';
 import ErrorFallback from './Settlemented/index.error';
+import { currentPageState } from '@recoil/index';
 
 const SettlementsSetting = () => {
 
   const { reset } = useQueryErrorResetBoundary();
+
+  const [,setCurrentPage] = useRecoilState(currentPageState);
 
   const [startDate, setStartDate] = useState<Date | null>(new Date(getCurrentYearStartDate()));
   const [endDate, setEndDate] = useState<Date | null>(new Date(getCurrentYearEndDate()));
@@ -66,6 +69,7 @@ const SettlementsSetting = () => {
         return;
       }
       setSettlementsDate({ startDate, endDate });
+      setCurrentPage(1);
     }
   };
 

--- a/src/components/Settlements/SettlementsLeft/SettlementsSetting/index.tsx
+++ b/src/components/Settlements/SettlementsLeft/SettlementsSetting/index.tsx
@@ -71,7 +71,7 @@ const SettlementsSetting = () => {
 
   const CustomInput = forwardRef(({ value, onClick }: any, ref: any) => (
     <CustomInputContainer onClick={onClick} ref={ref}>
-            <span>{value}</span>
+            <InputText>{value}</InputText>
       <Calendar src={CalendarIcon} alt="캘린더" />
     </CustomInputContainer>
   ));
@@ -307,4 +307,8 @@ const CustomInputContainer = styled.button`
   background: #fff;
 
   cursor: pointer;
+`;
+
+const InputText = styled.div`
+  color: black;
 `;

--- a/src/components/Settlements/SettlementsRight/SettlementsBefore/index.tsx
+++ b/src/components/Settlements/SettlementsRight/SettlementsBefore/index.tsx
@@ -26,8 +26,6 @@ const SettlementsBefore = () => {
     return `${year}.${month < 10 ? '0' : ''}${month}.${day < 10 ? '0' : ''}${day}`;
   };
 
-  const isBeforeDueDate = currentDate.getDate() < 10;
-
   return (
     <Container>
     <InnerContainer>
@@ -43,10 +41,7 @@ const SettlementsBefore = () => {
         src={SyncIcon}
         alt="업데이트" />
       <UpdatedText>
-        {isBeforeDueDate
-          ? `매월 1일 00시 00분 업데이트`
-          : `매월 11일 00시 00분 업데이트`
-        }
+        매월 1일 00시 00분 업데이트
       </UpdatedText>
       </CommonContainer>
       </ExpectedContainer>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export { default as STATUS_CODES } from './lib/STATUS_CODES';
 export { default as ERROR_MODAL_MESSAGE } from './lib/ERROR_MODAL_MESSAGE';
+export { default as SORT_OPTION } from './lib/SORT_OPTION';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export { default as STATUS_CODES } from './lib/STATUS_CODES';
 export { default as ERROR_MODAL_MESSAGE } from './lib/ERROR_MODAL_MESSAGE';
 export { default as SORT_OPTION } from './lib/SORT_OPTION';
+export { default as SETTLEMENTS_TABLE_KEY } from './lib/SETTLEMENTS_TABLE_KEY';

--- a/src/constants/lib/SETTLEMENTS_TABLE_KEY.ts
+++ b/src/constants/lib/SETTLEMENTS_TABLE_KEY.ts
@@ -1,4 +1,4 @@
-const keyToLabelMap = {
+const SETTLEMENTS_TABLE_KEY = {
     'NO': 'NO',
     'coupon_number': '쿠폰번호',
     'coupon_name': '관리 쿠폰명',
@@ -10,4 +10,4 @@ const keyToLabelMap = {
     'complete_at': '정산 완료일'
   };
 
-export default keyToLabelMap;
+export default SETTLEMENTS_TABLE_KEY;

--- a/src/constants/lib/SORT_OPTION.ts
+++ b/src/constants/lib/SORT_OPTION.ts
@@ -1,5 +1,5 @@
 const SORT_OPTION = [
-    { key: 'couponDateDesc', text: '쿠폰 사용일 최근 순', value: 'couponDateDesc' },
+    { key: 'couponDateDesc', text: '쿠폰 적용일 최근 순', value: 'couponDateDesc' },
     { key: 'dateDesc', text: '정산 완료일 최근 순', value: 'dateDesc' },
     { key: 'amountDesc', text: '정산금액 많은 순', value: 'amountDesc' },
     { key: 'usageCountDesc', text: '사용건 많은 순', value: 'usageCountDesc' },

--- a/src/constants/lib/SORT_OPTION.ts
+++ b/src/constants/lib/SORT_OPTION.ts
@@ -1,0 +1,8 @@
+const SORT_OPTION = [
+    { key: 'couponDateDesc', text: '쿠폰 사용일 최근 순', value: 'couponDateDesc' },
+    { key: 'dateDesc', text: '정산 완료일 최근 순', value: 'dateDesc' },
+    { key: 'amountDesc', text: '정산금액 많은 순', value: 'amountDesc' },
+    { key: 'usageCountDesc', text: '사용건 많은 순', value: 'usageCountDesc' },
+];
+
+export default SORT_OPTION;

--- a/src/hooks/queries/useGetSettlements.ts
+++ b/src/hooks/queries/useGetSettlements.ts
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getSettlements } from 'src/api';
 
 export const useGetSettlements = (
-  accommodationId: number,
+  accommodation_id: number,
   start: string, 
   end: string, 
   order: string, 
@@ -11,6 +11,6 @@ export const useGetSettlements = (
   pageSize: number
 ) =>
   useSuspenseQuery({
-    queryKey: ['Settlements', accommodationId, start, end, order, page],
-    queryFn: () => getSettlements(accommodationId, start, end, order, page, pageSize)
+    queryKey: ['Settlements', accommodation_id, start, end, order, page],
+    queryFn: () => getSettlements(accommodation_id, start, end, order, page, pageSize)
   });

--- a/src/recoil/atoms/settlementedPagination.ts
+++ b/src/recoil/atoms/settlementedPagination.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const currentPageState = atom({
+    key: 'currentPageState',
+    default: 1,
+});
+
+export default currentPageState;

--- a/src/recoil/index.ts
+++ b/src/recoil/index.ts
@@ -4,3 +4,4 @@ export { default as registerValidState } from './atoms/registerValidState';
 export { default as previewState } from './atoms/previewState';
 export { default as couponListState } from './atoms/couponListState';
 export { default as selectedYearState } from './atoms/selectedYearState';
+export { default as currentPageState } from './atoms/settlementedPagination'; 

--- a/src/types/settlements.ts
+++ b/src/types/settlements.ts
@@ -29,11 +29,15 @@ export interface SettlementList {
 };
 
 export interface SettlementedList {
+    total_cancel_price: number;
+    total_coupon_count: number;
+    total_discount_price: number;
+    total_sum_price: number;
     total_settlement_count: number;
     total_page_count: number;
     settlement_responses: SettlementedItem[];
 };
-  
+
 export interface SettlementedItem {
     NO: number;
     coupon_use_date: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,3 +30,4 @@ export {
   validateLabel,
   validateMaximumDiscount
 } from './lib/validationUtils';
+export { convertKeysToKorean } from './lib/convertKeysToKorean';

--- a/src/utils/lib/convertKeysToKorean.ts
+++ b/src/utils/lib/convertKeysToKorean.ts
@@ -1,0 +1,14 @@
+import { SettlementedItem } from '@/types/settlements';
+
+export const convertKeysToKorean = (data: SettlementedItem) => {
+  return {
+    '쿠폰 적용일': data.coupon_use_date,
+    '쿠폰번호': data.coupon_number,
+    '관리 쿠폰명': data.coupon_name,
+    '사용건수': data.coupon_count,
+    '쿠폰 할인 금액': data.discount_price,
+    '쿠폰 취소 금액': data.cancel_price,
+    '정산 금액': data.sum_price,
+    '정산 완료일': data.complete_at
+  };
+};

--- a/src/utils/lib/convertKeysToKorean.ts
+++ b/src/utils/lib/convertKeysToKorean.ts
@@ -2,13 +2,13 @@ import { SettlementedItem } from '@/types/settlements';
 
 export const convertKeysToKorean = (data: SettlementedItem) => {
   return {
-    '쿠폰 적용일': data.coupon_use_date,
     '쿠폰번호': data.coupon_number,
     '관리 쿠폰명': data.coupon_name,
     '사용건수': data.coupon_count,
     '쿠폰 할인 금액': data.discount_price,
     '쿠폰 취소 금액': data.cancel_price,
     '정산 금액': data.sum_price,
+    '쿠폰 적용일': data.coupon_use_date,
     '정산 완료일': data.complete_at
   };
 };


### PR DESCRIPTION
close #114 

## Description

작업 내용은 다음과 같습니다.

- 모바일에서 이전 정산 내역 키값 영어 -> 한글 변경
- 엑셀 다운로드 시 정산 요약 내역 추가
- 드롭다운 기본 텍스트 위치 조정
- 이전 정산 내역 로딩 및 에러 컴포넌트 크기 조정

QA 통한 수정 내역
- 전 달 정산 내역 UX 변경(매월 11일 업데이트 -> 매월 1일 업데이트)
- 모바일 환경에서 캘린더 텍스트 색상 파란색으로 설정되는 부분 해결(배포 후 확인 필요함)
- 드롭다운 텍스트 쿠폰 사용일 최근 순 -> 쿠폰 적용일 최근 순으로 변경
- 팝업 텍스트 구폰 적용일 -> 쿠폰 적용일로 변경
- 조회 기간 설정 시, 페이지네이션 초기화 안되는 문제 해결

## 유의할 점 및 ETC (Optional)

페이지 이동할 때 loading 화면이 너무 짧게 나와서 깜빡이는것처럼 보이는 현상은 아직 해결이 안됐습니다.


## 스크린샷 (Optional)
![image](https://github.com/CoolPeace-yanolza/frontend/assets/104253583/2ed30568-749f-44e6-9436-b4347ab6822e)

![image](https://github.com/CoolPeace-yanolza/frontend/assets/104253583/56c5235a-ac68-4a6e-9efc-a774d0148cd1)

![image](https://github.com/CoolPeace-yanolza/frontend/assets/104253583/562b5563-5f6a-4de3-91d2-e3214677a2f5)

![image](https://github.com/CoolPeace-yanolza/frontend/assets/104253583/84d93348-9552-47d1-9921-5ccbf0ad9f9f)

![image](https://github.com/CoolPeace-yanolza/frontend/assets/104253583/d3351385-d025-48c6-9c99-7e3c6c10bbbb)

![image](https://github.com/CoolPeace-yanolza/frontend/assets/104253583/88b92132-af0e-45eb-9029-e469816c7bb0)
