### PR TITLE
[#164] 로그인 게스트 계정 기본 설정

### DIFF
--- a/src/api/lib/instance.ts
+++ b/src/api/lib/instance.ts
@@ -71,8 +71,10 @@ const onErrorResponse = async (error: AxiosResponseError<string>) => {
       }
     }
     console.log(error.response.data.code, error.response);
+    return Promise.reject(error);
   }
   console.log('response error : ', error);
+  return Promise.reject(error);
 };
 
 // 요청 인터셉터 추가

--- a/src/components/Auth/AuthButton/index.tsx
+++ b/src/components/Auth/AuthButton/index.tsx
@@ -43,6 +43,8 @@ const SubmitButton = styled.button<AuthButtonStyleProps>`
       return '#C1C1C1';
     } else if (props.$variant === 'pink') {
       return 'linear-gradient(91deg, #FF3478 1.39%, #FF83AD 98.63%)';
+    } else if (props.$variant === 'skyblue') {
+      return 'linear-gradient(89.18deg, #3182F6 0%, #6AB2FF 111.65%)';
     } else {
       return '#1A2849';
     }

--- a/src/components/Login/LoginForm/index.tsx
+++ b/src/components/Login/LoginForm/index.tsx
@@ -21,12 +21,20 @@ const LoginForm = ({ handleModalOpen }: LoginFormProps) => {
   const navigate = useNavigate();
   const { state } = useLocation();
 
-  const methods = useForm({ mode: 'onBlur' });
+  const methods = useForm({
+    mode: 'onBlur'
+  });
   const {
+    setValue,
     formState: { errors },
     handleSubmit
   } = methods;
   const isError = !!errors?.login_id || !!errors?.login_password ? true : false;
+
+  const setDefaultValues = async () => {
+    setValue('login_id', 'prince@gmail.com');
+    setValue('login_password', 'test1234!');
+  };
 
   const movetoSignUp = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -109,6 +117,13 @@ const LoginForm = ({ handleModalOpen }: LoginFormProps) => {
             variant="pink"
             text="회원가입"
             buttonFunc={movetoSignUp}
+          />
+          <AuthButton
+            buttonType="button"
+            size="large"
+            variant="skyblue"
+            text="게스트 계정으로 둘러보기"
+            buttonFunc={setDefaultValues}
           />
         </Buttons>
       </form>

--- a/src/utils/lib/cookies.ts
+++ b/src/utils/lib/cookies.ts
@@ -3,7 +3,6 @@ import { SetCookies, GetCookies } from '@/types/auth';
 export const setCookies: SetCookies = (name, value, expiresIn) => {
   try {
     document.cookie = `${name}=${value};max-age=${expiresIn};path=/;secure`;
-    console.log(`${name}: 쿠키설정 성공`);
   } catch (error) {
     console.log(error);
     alert(`${name}: 쿠키설정에 실패했습니다.`);


### PR DESCRIPTION
close #164 

## Description

리드미를 참고하거나, 회원가입을 하지 않고도 배포 사이트를 둘러볼 수 있도록 게스트 계정을 추가하였습니다.

기존 로그인, 회원가입 버튼 아래에 `게스트 계정으로 둘러보기` 라는 버튼을 추가하여 해당 버튼 클릭 시 게스트 계정으로 설정된 값이 input에 입력됩니다.

## 스크린샷 (Optional)

https://github.com/CoolPeace-yanolza/frontend/assets/139190686/66de5a6e-d0e9-4180-a1df-bba604495643


